### PR TITLE
fix: fail closed on ML-DSA-87 private key PEM signing (no silent Dilithium downgrade)

### DIFF
--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ func main() {
 						}
 						var signature string
 						if isPrivateKey {
-							signature, err = sign.SignStringWithPrivateKey(files[0], privateKeyHex)
+							signature, err = sign.SignStringWithPrivateKeyAndAlgorithm(files[0], privateKeyHex, algorithm, context)
 						} else if algorithm == qcrypto.AlgorithmMLDSA {
 							signature, err = sign.SignStringWithAlgorithm(files[0], hexseed, algorithm, context)
 						} else {
@@ -476,7 +476,7 @@ func main() {
 						}
 						var signature string
 						if isPrivateKey {
-							signature, err = sign.SignFileWithPrivateKey(file, privateKeyHex)
+							signature, err = sign.SignFileWithPrivateKeyAndAlgorithm(file, privateKeyHex, algorithm, context)
 						} else if algorithm == qcrypto.AlgorithmMLDSA {
 							signature, err = sign.SignFileWithAlgorithm(file, hexseed, algorithm, context)
 						} else {

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/theQRL/go-qrllib/crypto/dilithium"
+	"github.com/theQRL/go-qrllib/crypto/ml_dsa_87"
 	"github.com/theQRL/qrlft/crypto"
 )
 
@@ -24,13 +25,38 @@ func SignMessage(message []byte, hexseed string) (string, error) {
 	return hex.EncodeToString(signature[:]), nil
 }
 
-// SignMessageWithPrivateKey signs a message using a private key (secret key) directly
+// SignMessageWithPrivateKey signs a message using a private key (secret key) directly.
+// The algorithm must match the key material: an ML-DSA-87 private key PEM is never
+// silently signed with Dilithium. Use SignMessageWithPrivateKeyAndAlgorithm when the
+// requested algorithm is known (as the CLI does).
 func SignMessageWithPrivateKey(message []byte, privateKeyHex string) (string, error) {
+	return SignMessageWithPrivateKeyAndAlgorithm(message, privateKeyHex, crypto.AlgorithmDilithium, nil)
+}
+
+// SignMessageWithPrivateKeyAndAlgorithm signs a message using a private key (secret key)
+// directly for the requested algorithm. The secret key length is validated against the
+// requested algorithm's constants, so an ML-DSA-87 secret key can never be fed to the
+// pre-FIPS Dilithium routine (which would silently drop the FIPS 204 context binding).
+func SignMessageWithPrivateKeyAndAlgorithm(message []byte, privateKeyHex, algorithm string, context []byte) (string, error) {
 	skBytes, err := hex.DecodeString(privateKeyHex)
 	if err != nil {
 		return "", errors.New("failed to decode private key: " + err.Error())
 	}
 	defer crypto.ZeroBytes(skBytes) // Zero decoded key bytes when done
+
+	if algorithm == crypto.AlgorithmMLDSA {
+		if len(skBytes) != ml_dsa_87.CRYPTO_SECRET_KEY_BYTES {
+			return "", errors.New("invalid ML-DSA-87 private key length")
+		}
+		if context == nil {
+			return "", errors.New("context is required for ML-DSA-87 (use --context flag)")
+		}
+		// go-qrllib currently has no public API to construct an ML-DSA-87 signer
+		// from a secret key (the FIPS 204 secret key is a one-way expansion of the
+		// seed, so the hexseed cannot be recovered from it). Fail closed rather
+		// than silently producing a context-less Dilithium signature.
+		return "", errors.New("ML-DSA-87 private key PEM signing is not supported yet; use the hexseed file (--keyfile=<name>.private.hexseed) instead")
+	}
 
 	if len(skBytes) != dilithium.CRYPTO_SECRET_KEY_BYTES {
 		return "", errors.New("invalid private key length")
@@ -62,7 +88,9 @@ func SignString(stringToSign string, hexseed string) (string, error) {
 	return SignMessage([]byte(stringToSign), hexseed)
 }
 
-// SignFileWithPrivateKey signs a file using a private key directly
+// SignFileWithPrivateKey signs a file using a private key directly (Dilithium, for
+// backward compatibility). Use SignFileWithPrivateKeyAndAlgorithm when the requested
+// algorithm is known (as the CLI does).
 func SignFileWithPrivateKey(filename string, privateKeyHex string) (string, error) {
 	message, err := readFile(filename)
 	if err != nil {
@@ -71,9 +99,27 @@ func SignFileWithPrivateKey(filename string, privateKeyHex string) (string, erro
 	return SignMessageWithPrivateKey(message, privateKeyHex)
 }
 
-// SignStringWithPrivateKey signs a string using a private key directly
+// SignFileWithPrivateKeyAndAlgorithm signs a file using a private key directly
+// for the requested algorithm.
+func SignFileWithPrivateKeyAndAlgorithm(filename, privateKeyHex, algorithm string, context []byte) (string, error) {
+	message, err := readFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return SignMessageWithPrivateKeyAndAlgorithm(message, privateKeyHex, algorithm, context)
+}
+
+// SignStringWithPrivateKey signs a string using a private key directly (Dilithium, for
+// backward compatibility). Use SignStringWithPrivateKeyAndAlgorithm when the requested
+// algorithm is known (as the CLI does).
 func SignStringWithPrivateKey(stringToSign string, privateKeyHex string) (string, error) {
 	return SignMessageWithPrivateKey([]byte(stringToSign), privateKeyHex)
+}
+
+// SignStringWithPrivateKeyAndAlgorithm signs a string using a private key directly
+// for the requested algorithm.
+func SignStringWithPrivateKeyAndAlgorithm(stringToSign, privateKeyHex, algorithm string, context []byte) (string, error) {
+	return SignMessageWithPrivateKeyAndAlgorithm([]byte(stringToSign), privateKeyHex, algorithm, context)
 }
 
 // SignMessageWithSigner signs a message using a Signer interface

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -328,6 +328,44 @@ func TestSignMessageWithPrivateKeyWrongLength(t *testing.T) {
 	}
 }
 
+// TestMLDSAPrivateKeyFailsClosed verifies that an ML-DSA-87 private key is never
+// silently signed with pre-FIPS Dilithium (regression test for the silent
+// algorithm downgrade: the ML-DSA-87 secret key is the same size as the
+// Dilithium secret key, so the old length-only check let it through).
+func TestMLDSAPrivateKeyFailsClosed(t *testing.T) {
+	// Generate an ML-DSA-87 keypair (same 4896-byte secret key size as Dilithium)
+	signer, err := crypto.NewKeypair(crypto.AlgorithmMLDSA, []byte("test-context"))
+	if err != nil {
+		t.Fatalf("NewKeypair(mldsa) error = %v", err)
+	}
+	skHex := hex.EncodeToString(signer.GetSK())
+
+	// The CLI path: sign with the private key while requesting ML-DSA.
+	// This must fail closed instead of producing a Dilithium signature.
+	_, err = SignMessageWithPrivateKeyAndAlgorithm([]byte("test"), skHex, crypto.AlgorithmMLDSA, []byte("test-context"))
+	if err == nil {
+		t.Fatal("SignMessageWithPrivateKeyAndAlgorithm(mldsa) expected error, got a signature (silent downgrade)")
+	}
+
+	// The CLI path with an ML-DSA key file must not silently fall back to
+	// Dilithium either.
+	_, err = SignMessageWithPrivateKeyAndAlgorithm([]byte("test"), skHex, crypto.AlgorithmMLDSA, nil)
+	if err == nil {
+		t.Fatal("SignMessageWithPrivateKeyAndAlgorithm(mldsa, no context) expected error, got a signature (silent downgrade)")
+	}
+
+	// Control: a genuine Dilithium private key still signs fine (backward compat).
+	dil, _ := crypto.NewKeypair(crypto.AlgorithmDilithium, nil)
+	dilSkHex := hex.EncodeToString(dil.GetSK())
+	sig, err := SignMessageWithPrivateKey([]byte("test"), dilSkHex)
+	if err != nil {
+		t.Fatalf("SignMessageWithPrivateKey() with Dilithium key error = %v", err)
+	}
+	if len(sig) == 0 {
+		t.Error("SignMessageWithPrivateKey() with Dilithium key returned empty signature")
+	}
+}
+
 func TestSignFileNonexistent(t *testing.T) {
 	hexseed := "d2003016f53e800092ecd8d8d3cb43208c73baf505f7710d1f4cee82c601f921"
 	_, err := SignFile("/nonexistent/file.txt", hexseed)


### PR DESCRIPTION
# PR body for theQRL/qrlft — fix/mldsa-private-key-silent-downgrade

## Summary

When signing with an **ML-DSA-87 private key PEM file** (`qrlft sign --algorithm=mldsa --context=... --keyfile=<file>`), the private-key branch in `main.go` dispatched to the legacy Dilithium-only helpers `SignFileWithPrivateKey`/`SignStringWithPrivateKey`, which **silently signed with pre-FIPS round-3 Dilithium instead of ML-DSA-87**, dropping the mandatory FIPS 204 context domain separation — even though the user explicitly requested ML-DSA with a context.

Because the ML-DSA-87 secret key and the Dilithium secret key are the same size (4896 bytes), the length check passed and the ML-DSA secret key was fed to `dilithium.SignWithSecretKey` unchanged. Verified end-to-end: the resulting signature **fails ML-DSA verification with the user's context** ("Signature is not valid") yet **verifies as plain Dilithium** — the tool cannot verify its own output.

## Fix

The private-key branch now routes through new algorithm-aware helpers (`SignMessageWithPrivateKeyAndAlgorithm` / `SignFileWithPrivateKeyAndAlgorithm` / `SignStringWithPrivateKeyAndAlgorithm`):

- Secret key length is validated against the **requested** algorithm's constants (`ml_dsa_87.CRYPTO_SECRET_KEY_BYTES` vs `dilithium.CRYPTO_SECRET_KEY_BYTES`)
- Context is required for ML-DSA-87 (previously silently dropped)
- **Fail closed for ML-DSA-87 private key PEM files**: go-qrllib currently provides no public API to construct an ML-DSA-87 signer from a secret key (the FIPS 204 secret key is a one-way expansion of the seed, so the hexseed cannot be recovered from it), so the command now returns an explicit error directing the user to the hexseed file instead of silently producing a context-less Dilithium signature

The old `SignMessageWithPrivateKey`/`SignFileWithPrivateKey`/`SignStringWithPrivateKey` signatures are kept for backward compatibility (Dilithium-only, documented as such).

## Behavior change

| Command | Before | After |
|---|---|---|
| `sign --algorithm=mldsa --context=... --keyfile=<ml-dsa-sk.pem>` | exit 0, **silent Dilithium signature** (unverifiable as ML-DSA) | exit 79, clear error + pointer to hexseed file |
| `sign --algorithm=mldsa --context=... --keyfile=<name>.private.hexseed` | works | works (unchanged) |
| `sign --algorithm=dilithium --keyfile=<dilithium-sk.pem>` | works | works (unchanged) |

## Tests

- New `TestMLDSAPrivateKeyFailsClosed` in `sign/sign_test.go` — regression test covering the CLI signing path and the no-context case, with a genuine Dilithium key as the backward-compat control
- `go test ./...` — all packages pass

## Security impact

- **CWE-328 / CWE-757**: silent selection of a less-secure legacy algorithm during negotiation; FIPS 204 context domain separation dropped
- Signature confusion/replay across pre-FIPS Dilithium and ML-DSA systems sharing key material
- Broken pipeline: the tool could not verify signatures it produced via its own documented private-key flow

Note: full ML-DSA-87 private-key PEM signing support would require go-qrllib to expose an SK-based signer constructor (e.g., `NewMLDSA87FromSecretKey`); this change makes the CLI safe (fail-closed) regardless.
